### PR TITLE
Update detect

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "sphinx-3.0.2-2592786-linux-amd64.tar.gz"
+echo "Sphinx"
 exit 0


### PR DESCRIPTION
This should evidently just echo a descriptor since we are not doing an explicit detect for any Sphinx files in the app build directory.